### PR TITLE
option to disable verbosity limits.

### DIFF
--- a/cmp/report.go
+++ b/cmp/report.go
@@ -4,6 +4,10 @@
 
 package cmp
 
+// LimitVerbosity applies the default verbosity limits. Set to false to have it
+// verbose.
+var LimitVerbosity = true
+
 // defaultReporter implements the reporter interface.
 //
 // As Equal serially calls the PushStep, Report, and PopStep methods, the

--- a/cmp/report_compare.go
+++ b/cmp/report_compare.go
@@ -98,10 +98,12 @@ func verbosityPreset(opts formatOptions, i int) formatOptions {
 // FormatDiff converts a valueNode tree into a textNode tree, where the later
 // is a textual representation of the differences detected in the former.
 func (opts formatOptions) FormatDiff(v *valueNode, ptrs *pointerReferences) (out textNode) {
-	if opts.DiffMode == diffIdentical {
-		opts = opts.WithVerbosity(1)
-	} else {
-		opts = opts.WithVerbosity(3)
+	if LimitVerbosity {
+		if opts.DiffMode == diffIdentical {
+			opts = opts.WithVerbosity(1)
+		} else {
+			opts = opts.WithVerbosity(3)
+		}
 	}
 
 	// Check whether we have specialized formatting for this node.


### PR DESCRIPTION
This is ugly as hell, but so is go-cmp and I'm NOT going to fix that mess.

Exhibit A:

![image](https://user-images.githubusercontent.com/1101242/102643302-f5194900-4156-11eb-84c0-e8a348d1b372.png)

Exhibit B:

All options appear to be configurable with public fields and all, and public functional options-style builders, but they're not.